### PR TITLE
Fix build on Windows

### DIFF
--- a/src/TSOSCCommon.hpp
+++ b/src/TSOSCCommon.hpp
@@ -2,6 +2,9 @@
 #define TSOSCCOMMON_HPP
 
 #include <string>
+#if defined ARCH_WIN
+#include <cstdint>
+#endif
 
 //--- OSC defines --
 // Default OSC outgoing address (Tx). 127.0.0.1.


### PR DESCRIPTION
```
g++ -std=c++11 -Wsuggest-override  -fPIC -I../../include -I../../dep/include -MMD -MP -g -O3 -funsafe-math-optimizations -fno-omit-frame-pointer -Wall -Wextra -Wno-unused-parameter -DARCH_X64 -march=nehalem -DARCH_WIN -D_USE_MATH_DEFINES -municode  -c -o build/src/TSOSCCommon.cpp.o src/TSOSCCommon.cpp
In file included from src/TSOSCCommon.cpp:1:
src/TSOSCCommon.hpp:19:16: error: found ':' in nested-name-specifier, expected '::'
   19 | enum OSCClient : uint8_t {
      |                ^
      |                ::
src/TSOSCCommon.hpp:19:6: error: 'OSCClient' has not been declared
   19 | enum OSCClient : uint8_t {
      |      ^~~~~~~~~
src/TSOSCCommon.hpp:19:26: error: expected unqualified-id before '{' token
   19 | enum OSCClient : uint8_t {
      |                          ^
src/TSOSCCommon.hpp:30:33: error: 'NUM_OSC_CLIENTS' was not declared in this scope
   30 | extern std::string OSCClientStr[NUM_OSC_CLIENTS];
      |                                 ^~~~~~~~~~~~~~~
src/TSOSCCommon.hpp:32:34: error: 'NUM_OSC_CLIENTS' was not declared in this scope
   32 | extern std::string OSCClientAbbr[NUM_OSC_CLIENTS];
      |                                  ^~~~~~~~~~~~~~~
src/TSOSCCommon.cpp:6:26: error: 'NUM_OSC_CLIENTS' was not declared in this scope
    6 | std::string OSCClientStr[NUM_OSC_CLIENTS] = { "Generic", "touchOSC" };// , "Lemur" };
      |                          ^~~~~~~~~~~~~~~
src/TSOSCCommon.cpp:7:27: error: 'NUM_OSC_CLIENTS' was not declared in this scope
    7 | std::string OSCClientAbbr[NUM_OSC_CLIENTS] = { "Gen", "tOSC" };// , "Lemr" };
      |                           ^~~~~~~~~~~~~~~
make: *** [../../compile.mk:89: build/src/TSOSCCommon.cpp.o] Error 1
make: *** Waiting for unfinished jobs....
```